### PR TITLE
fix: use newer hardhat command for contract deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ npx hardhat compile
 npx hardhat test
 # !!! Edit constructor_params.js file to choose which class IDs you want !!! The default is one of each class.
 # Test the deploy tx
-npx hardhat node
-npx hardhat run --network localhost scripts/deploy.ts
+npx hardhat run scripts/deploy.ts
 # Actually deploy
 npx hardhat run --network fantom scripts/deploy.ts
 ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ npx hardhat compile
 npx hardhat test
 # !!! Edit constructor_params.js file to choose which class IDs you want !!! The default is one of each class.
 # Test the deploy tx
-npx hardhat deploy 
+npx hardhat node
+npx hardhat run --network localhost scripts/deploy.ts
 # Actually deploy
-npx hardhat deploy --network fantom
+npx hardhat run --network fantom scripts/deploy.ts
 ```
 
 Afterwards navigate to your deployed contract on ftmscan and use adventureAll() to adventure your entire party!


### PR DESCRIPTION
- `hardhat deploy` is no longer available in the latest hardhat
- ref: https://hardhat.org/guides/deploying.html